### PR TITLE
Refactor display output

### DIFF
--- a/pip_cl.ado
+++ b/pip_cl.ado
@@ -590,21 +590,18 @@ end
 //------------ display results
 program define pip_cl_display_results
 	
-	syntax , [n2disp(numlist)]
-	
-	if ("`n2disp'" == "") local n2disp 1
+	syntax , [n2disp(scalar 1)]
+
 	local n2disp = min(`c(N)', `n2disp')
 	
-	if (`n2disp' > 1) {
-		noi di as res _n "{ul: first `n2disp' observations}"
-	} 
-	else	if (`n2disp' == 1) {
-		noi di as res _n "{ul: first observation}"
-	}
-	else {
-		noi di as res _n "{ul: No observations available}"
-	}	
-	
+	//Display header
+	if      `n2disp'==1 local MSG "first observation"
+	else if `n2disp' >1 local MSG "first `n2disp' observations"
+	else                local MSG "No observations available"
+	noi dis as result _n "{ul:`MSG'}" 
+
+
+	//Display contents
 	sort country_code year
 	local varstodisp "country_code year poverty_line headcount mean median welfare_type"
 	local sepby "country_code"
@@ -613,11 +610,8 @@ program define pip_cl_display_results
 		cap confirm var `v', exact
 		if _rc continue 
 		local v2d "`v2d' `v'"
-	}
-	
+	}	
 	noi list `v2d' in 1/`n2disp',  abbreviate(12)  sepby(`sepby') noobs
-	
-	
 end
 
 

--- a/pip_cl.ado
+++ b/pip_cl.ado
@@ -25,7 +25,7 @@ program define pip_cl, rclass
 	
 	if ("`pause'" == "pause") pause on
 	else                      pause off
-	
+
 	qui {
 		//========================================================
 		// setup
@@ -71,13 +71,12 @@ program define pip_cl, rclass
 		local datalabel = substr("`datalabel'", 1, 80)
 		
 		label data "`datalabel' (`c(current_date)')"
-		
+
 		//------------ display results
-		noi pip_cl_display_results, `n2disp'
-		//noi pip_utils output, `n2disp' /// 
-		//sortvars(country_code year) /// 
-		//dispvars(country_code year poverty_line headcount mean median welfare_type) ///
-		//sepvar(country_code)		
+		noi pip_utils output, `n2disp' /// 
+		 sortvars(country_code year) /// 
+		 dispvars(country_code year poverty_line headcount mean median welfare_type) ///
+		 sepvar(country_code)		
 		
 		//------------ Povcalnet format
 		
@@ -302,8 +301,13 @@ program define pip_cl_check_args, rclass
 	if ("`country'" == "") local country "all" // to modify
 	return local country = "`country'"
 	local optnames "`optnames' country"
+
+	// allow n2disp as undocumented option
+	if ("`n2disp'" != "") {
+		return local n2disp = "`n2disp'"
+		local optnames "`optnames' n2disp"
+	}
 	return local optnames "`optnames'"
-   
 end
 
 //========================================================
@@ -320,8 +324,8 @@ program define pip_cl_query, rclass
 	REGion(string)                  /// 
 	YEAR(string)                    /// 
 	POVLine(numlist)                /// 
-	POPShare(numlist)	   	          /// 
-	PPP_version(numlist)                    /// 
+	POPShare(numlist)	   	        /// 
+	PPP_version(numlist)            /// 
 	COVerage(string)                /// 
 	FILLgaps                        /// 
 	] 
@@ -520,7 +524,7 @@ program define pip_cl_clean, rclass
 		label var cpi 				   "consumer price index (CPI) in `ppp_version' base"
 		label var reporting_gdp 	   "GDP per capita in constant 2015 US\$, annual calendar year"
 		label var reporting_pce 	   "HFCE per capita in constant 2015 US\$, annual calendar year"
-		cap label var estimate_type        "type of estimate"
+		cap label var estimate_type    "type of estimate"
 		
 		//========================================================
 		//  Sorting and Formatting
@@ -590,34 +594,6 @@ program define pip_cl_clean, rclass
 		
 	}			
 end
-
-//------------ display results
-program define pip_cl_display_results
-	
-	syntax , [n2disp(integer 1)]
-
-	local n2disp = min(`c(N)', `n2disp')
-	
-	//Display header
-	if      `n2disp'==1 local MSG "first observation"
-	else if `n2disp' >1 local MSG "first `n2disp' observations"
-	else                local MSG "No observations available"
-	noi dis as result _n "{ul:`MSG'}" 
-
-
-	//Display contents
-	sort country_code year
-	local varstodisp "country_code year poverty_line headcount mean median welfare_type"
-	local sepby "country_code"
-	
-	foreach v of local varstodisp {
-		cap confirm var `v', exact
-		if _rc continue 
-		local v2d "`v2d' `v'"
-	}	
-	noi list `v2d' in 1/`n2disp',  abbreviate(12)  sepby(`sepby') noobs
-end
-
 
 program define pip_cl_povcalnet
 	ren year       requestyear

--- a/pip_cl.ado
+++ b/pip_cl.ado
@@ -499,7 +499,7 @@ program define pip_cl_clean, rclass
 		label var gini 				"gini index"
 		label var median 			"median daily per capita income/consumption in `ppp_version' PPP US\$"
 		label var mld 				"mean log deviation"
-		label var reporting_pop 	"polarization"
+		label var polarization 	    "polarization"
 		label var reporting_pop     "population in year"
 		
 		ds decile*

--- a/pip_cl.ado
+++ b/pip_cl.ado
@@ -74,6 +74,10 @@ program define pip_cl, rclass
 		
 		//------------ display results
 		noi pip_cl_display_results, `n2disp'
+		//noi pip_utils output, `n2disp' /// 
+		//sortvars(country_code year) /// 
+		//dispvars(country_code year poverty_line headcount mean median welfare_type) ///
+		//sepvar(country_code)		
 		
 		//------------ Povcalnet format
 		

--- a/pip_cl.ado
+++ b/pip_cl.ado
@@ -590,7 +590,7 @@ end
 //------------ display results
 program define pip_cl_display_results
 	
-	syntax , [n2disp(scalar 1)]
+	syntax , [n2disp(integer 1)]
 
 	local n2disp = min(`c(N)', `n2disp')
 	

--- a/pip_cl.sthlp
+++ b/pip_cl.sthlp
@@ -138,7 +138,7 @@ for each country.
 {opt povline(#)} The poverty lines for which the poverty measures will be calculated. When selecting
 multiple poverty lines, use less than 4 decimals and separate each value with spaces. If
 left empty, the default poverty line of $2.15 is used. By default, poverty lines are expressed in
-2017 PPP USD per capita per day. If option {opt ppp_ppp(2011)} is specified, the poverty lines will be expressed in 2011 PPPs.
+2017 PPP USD per capita per day. If option {opt ppp_year(2011)} is specified, the poverty lines will be expressed in 2011 PPPs.
 
 {phang}
 {ul:{it:The following options only apply to cl}}

--- a/pip_cp.ado
+++ b/pip_cp.ado
@@ -284,7 +284,7 @@ end
 //------------ display results
 program define pip_cp_display_results
 
-	syntax , [n2disp(scalar 1)]
+	syntax , [n2disp(integer 1)]
 
 	local n2disp = min(`c(N)', `n2disp')  
 

--- a/pip_cp.ado
+++ b/pip_cp.ado
@@ -49,8 +49,7 @@ program define pip_cp, rclass
 		
 		//========================================================
 		// Getting data
-		//========================================================
-		
+		//========================================================		
 		//------------ download
 		pip_timer pip_cp.pip_get, on
 		pip_get, `clear' `cacheforce' `cachedir'
@@ -67,9 +66,15 @@ program define pip_cp, rclass
 		
 		label data "`datalabel' (`c(current_date)')"
 		
+		//========================================================
+		// Getting data
+		//========================================================		
 		//------------ display results
 		noi pip_cp_display_results, `n2disp'
-		
+		//noi pip_utils output, `n2disp' ///
+        //sortvars(country_code reporting_year) ///
+        //dispvars(country_code reporting_year poverty_line headcount welfare_time) ///
+        //sepvar(country_code)
 	}
 	pip_timer pip_cp, off
 end 
@@ -223,7 +228,6 @@ end
 //========================================================
 
 //------------ Build CP query
-
 program define pip_cp_query, rclass
 	version 16
 	syntax ///

--- a/pip_cp.ado
+++ b/pip_cp.ado
@@ -284,21 +284,17 @@ end
 //------------ display results
 program define pip_cp_display_results
 
-	syntax , [n2disp(numlist)]
+	syntax , [n2disp(scalar 1)]
+
+	local n2disp = min(`c(N)', `n2disp')  
+
+	//Display header
+	if      `n2disp'==1 local MSG "first observation" 
+	else if `n2disp' >1 local MSG "first `n2disp' observations"
+	else                local MSG "No observations available"
+	noi dis as result _n "{ul:`MSG'}"
 	
-	if ("`n2disp'" == "") local n2disp 1
-	local n2disp = min(`c(N)', `n2disp')
-	
-	if (`n2disp' > 1) {
-		noi di as res _n "{ul: first `n2disp' observations}"
-	} 
-	else	if (`n2disp' == 1) {
-		noi di as res _n "{ul: first observation}"
-	}
-	else {
-		noi di as res _n "{ul: No observations available}"
-	}	
-	
+	//Display contents
 	sort country_code reporting_year
 	local varstodisp "country_code reporting_year poverty_line headcount welfare_time"
 	local sepby "country_code"
@@ -307,10 +303,8 @@ program define pip_cp_display_results
 		cap confirm var `v', exact
 		if _rc continue 
 		local v2d "`v2d' `v'"
-	}
-	
+	}	
 	noi list `v2d' in 1/`n2disp',  abbreviate(12)  sepby(`sepby') noobs
-	
 end
 
 exit

--- a/pip_cp.ado
+++ b/pip_cp.ado
@@ -70,11 +70,10 @@ program define pip_cp, rclass
 		// Getting data
 		//========================================================		
 		//------------ display results
-		noi pip_cp_display_results, `n2disp'
-		//noi pip_utils output, `n2disp' ///
-        //sortvars(country_code reporting_year) ///
-        //dispvars(country_code reporting_year poverty_line headcount welfare_time) ///
-        //sepvar(country_code)
+		noi pip_utils output, `n2disp' ///
+          sortvars(country_code reporting_year) ///
+          dispvars(country_code reporting_year poverty_line headcount welfare_time) ///
+          sepvar(country_code)
 	}
 	pip_timer pip_cp, off
 end 
@@ -131,6 +130,13 @@ program define pip_cp_check_args, rclass
 	
 	return local povline  = "`povline'"
 	local optnames "`optnames' povline"
+
+	// allow n2disp as undocumented option
+	if ("`n2disp'"!="" ) {
+		return local n2disp = "`n2disp'"
+		local optnames "`optnames' n2disp"
+	}
+	
 	return local optnames "`optnames'"
    
 end
@@ -282,33 +288,6 @@ program define pip_cp_query, rclass
 		mata: st_global("pip_last_queries", invtokens(`M'))
 	}
 	
-end
-
-
-//------------ display results
-program define pip_cp_display_results
-
-	syntax , [n2disp(integer 1)]
-
-	local n2disp = min(`c(N)', `n2disp')  
-
-	//Display header
-	if      `n2disp'==1 local MSG "first observation" 
-	else if `n2disp' >1 local MSG "first `n2disp' observations"
-	else                local MSG "No observations available"
-	noi dis as result _n "{ul:`MSG'}"
-	
-	//Display contents
-	sort country_code reporting_year
-	local varstodisp "country_code reporting_year poverty_line headcount welfare_time"
-	local sepby "country_code"
-	
-	foreach v of local varstodisp {
-		cap confirm var `v', exact
-		if _rc continue 
-		local v2d "`v2d' `v'"
-	}	
-	noi list `v2d' in 1/`n2disp',  abbreviate(12)  sepby(`sepby') noobs
 end
 
 exit

--- a/pip_cp.sthlp
+++ b/pip_cp.sthlp
@@ -57,7 +57,7 @@ three-letter codes separated by spaces. The option {it:all} is a shorthand for c
 When selecting multiple poverty lines, use less than 4 decimals and separate
 each value with spaces. If left empty, the default poverty line of $2.15 is used.
 By default, poverty lines are expressed in 2017 PPP USD per capita per day.
-If option {opt ppp_ppp(2011)} is specified, the poverty lines will be expressed in 2011 PPPs. {p_end}
+If option {opt ppp_year(2011)} is specified, the poverty lines will be expressed in 2011 PPPs. {p_end}
 {synoptline}
 {synopt :{helpb pip##general_options: general options}}Options that apply to any subcommand{p_end}
 

--- a/pip_utils.ado
+++ b/pip_utils.ado
@@ -6,7 +6,7 @@ url:
 Dependencies:  The World Bank
 ----------------------------------------------------
 Creation Date:    16 May 2023 - 18:14:47
-Modification Date:   
+Modification Date:   21 Jul 2024 - 20:39:11 (DClarke)
 Do-file version:    01
 References:          
 Output:             
@@ -29,7 +29,7 @@ program define pip_utils, rclass
 		local subcmd = trim(ustrregexs(1))
 		local if = trim(ustrregexs(2))
 	}
-		//========================================================
+	//========================================================
 	// Execute 
 	//========================================================
 	
@@ -61,7 +61,11 @@ program define pip_utils, rclass
 	if ustrregexm("`subcmd'", "^click"){
 		pip_utils_clicktable `if', `variable' `title' `statacode' `length' `width'
 	}
-	
+
+	//------------ Output result disply
+	if ("`subcmd'" == "output") {
+		noi pip_utils_output, `n2disp' `sortvars' `dispvars' `sepvar' `worldcheck'
+	}
 	
 	
 end
@@ -235,6 +239,46 @@ program define pip_utils_clicktable
 	disp _n
 	
 end
+
+//------------ Final display message
+program define pip_utils_output
+	syntax  [, ///
+		n2disp(integer 1) ///
+		sortvars(varlist) ///
+		dispvars(varlist) ///
+		sepvar(varlist)   ///
+		worldcheck        ///
+	]
+	local n2disp = min(`c(N)', `n2disp')
+	
+	//Display header
+	if      `n2disp'==1 local MSG "first observation"
+	else if `n2disp' >1 local MSG "first `n2disp' observations"
+	else                local MSG "No observations available"
+	noi dis as result _n "{ul:`MSG'}"
+
+	//Worldcheck checks if observations should be displayed only for WLD region
+	local rflag=0
+	if "`worldcheck'"!="" {
+		qui count if region_code=="WLD"
+		if `r(N)'>=`n2disp' {
+            preserve
+            qui keep if region_code=="WLD"
+            local rflag=1
+        }
+	}
+	
+	//DISPLAY OUTPUT
+	//Arguments below could be generalised to argument if desired
+	local dispopts abbreviate(12) noobs
+	//Sort if specified [could also use gsort if and remove varlist]
+	if "`sortvars'"!="" sort `sortvars'
+	//Print output
+	if `n2disp'!=0 noi list `dispvars' in 1/`n2disp', `dispopts' sepby(`sepvars')
+	if `rflag'==1 restore
+
+end
+
 
 
 exit

--- a/pip_utils.ado
+++ b/pip_utils.ado
@@ -61,8 +61,7 @@ program define pip_utils, rclass
 	if ustrregexm("`subcmd'", "^click"){
 		pip_utils_clicktable `if', `variable' `title' `statacode' `length' `width'
 	}
-
-	//------------ Output result disply
+	//------------ Output result display
 	if ("`subcmd'" == "output") {
 		noi pip_utils_output, `n2disp' `sortvars' `dispvars' `sepvar' `worldcheck'
 	}

--- a/pip_wb.ado
+++ b/pip_wb.ado
@@ -66,7 +66,10 @@ program define pip_wb, rclass
 		
 		//------------ Display results
 		noi pip_wb_display_results, `n2disp'
-		
+		//noi pip_utils output, `n2disp' worldcheck ///
+		//sortvars(region_code year)                ///
+		//dispvars(region_code year poverty_line headcount mean)
+        
 		//------------ Povcalnet format
 		
 		if ("`povcalnet_format'" != "") {

--- a/pip_wb.ado
+++ b/pip_wb.ado
@@ -65,10 +65,9 @@ program define pip_wb, rclass
 		label data "`datalabel' (`c(current_date)')"
 		
 		//------------ Display results
-		noi pip_wb_display_results, `n2disp'
-		//noi pip_utils output, `n2disp' worldcheck ///
-		//sortvars(region_code year)                ///
-		//dispvars(region_code year poverty_line headcount mean)
+		noi pip_utils output, `n2disp' worldcheck   ///
+		  sortvars(region_code year)                ///
+		  dispvars(region_code year poverty_line headcount mean)
         
 		//------------ Povcalnet format
 		
@@ -225,6 +224,12 @@ program define pip_wb_check_args, rclass
 	if ("`clear'" == "") local clear "clear"
 	return local clear = "`clear'"
 	local optnames "`optnames' clear"
+
+	// allow n2disp as undocumented option
+	if ("`n2disp'" != "") {
+		return local n2disp = "`n2disp'"
+		local optnames "`optnames' n2disp"
+	}
 	return local optnames "`optnames'"
 
 end
@@ -364,37 +369,6 @@ program define pip_wb_clean, rclass
 	}
 	
 end
-
-//------------ display results
-program define pip_wb_display_results
-	
-	syntax , [n2disp(integer 1)]
-
-	local n2disp = min(`c(N)', `n2disp')
-	//Display header
-	if      `n2disp'==1 local MSG "first observation"
-	else if `n2disp' >1 local MSG "first `n2disp' observations"
-	else                local MSG "No observations available"
-	noi dis as result _n "{ul:`MSG'}"
-	
-	//Display contents
-	sort region_code year 
-	
-	tempname tolist
-	frame copy `c(frame)' `tolist'
-	qui frame `tolist' {
-		gsort region_code -year 
-		
-		count if (region_code == "WLD")
-		local cwld = r(N)
-		if (`cwld' >= `n2disp') {
-			keep if (region_code == "WLD")			
-		}
-		noi list region_code year poverty_line headcount mean ///
-		in 1/`n2disp',  abbreviate(12) noobs
-	}
-end
-
 
 program define pip_wb_povcalnet
 	ren year        requestyear

--- a/pip_wb.ado
+++ b/pip_wb.ado
@@ -365,21 +365,16 @@ end
 //------------ display results
 program define pip_wb_display_results
 	
-	syntax , [n2disp(numlist)]
-	
-	if ("`n2disp'" == "") local n2disp 1
+	syntax , [n2disp(scalar 1)]
+
 	local n2disp = min(`c(N)', `n2disp')
+	//Display header
+	if      `n2disp'==1 local MSG "first observation"
+	else if `n2disp' >1 local MSG "first `n2disp' observations"
+	else                local MSG "No observations available"
+	noi dis as result _n "{ul:`MSG'}"
 	
-	if (`n2disp' > 1) {
-		noi di as res _n "{ul: first `n2disp' observations}"
-	} 
-	else	if (`n2disp' == 1) {
-		noi di as res _n "{ul: first observation}"
-	}
-	else {
-		noi di as res _n "{ul: No observations available}"
-	}	
-	
+	//Display contents
 	sort region_code year 
 	
 	tempname tolist
@@ -395,7 +390,6 @@ program define pip_wb_display_results
 		noi list region_code year poverty_line headcount mean ///
 		in 1/`n2disp',  abbreviate(12) noobs
 	}
-	
 end
 
 

--- a/pip_wb.ado
+++ b/pip_wb.ado
@@ -365,7 +365,7 @@ end
 //------------ display results
 program define pip_wb_display_results
 	
-	syntax , [n2disp(scalar 1)]
+	syntax , [n2disp(integer 1)]
 
 	local n2disp = min(`c(N)', `n2disp')
 	//Display header


### PR DESCRIPTION
This standardises display output as a function pip_utils_output.  This is then called by pip_cl, pip_wb, and pip_cp in a seamless way.  A few minor other edits are addressed in help files and various labelling.