### PR TITLE
Corrects minor inconsistency if frame_gd is run twice with clear

### DIFF
--- a/pip_gd.ado
+++ b/pip_gd.ado
@@ -61,6 +61,11 @@ program define pip_gd,  rclass
 		}
 		local clear "clear"
 		
+		// If current frame is called _pip_gd, frame drop will fail, so rename
+		cap frame drop _pip_gd_old
+		if c(frame)=="_pip_gd" {
+			frame rename _pip_gd _pip_gd_old
+		}
 		cap frame drop _pip_gd
 		qui frame create _pip_gd
 		frame _pip_gd {


### PR DESCRIPTION
Hi @randrescastaneda 

This is a very small push.  I realised that now with the clear option if we run pip_gd twice in a row there will be a minor inconsistency and code will fail, as `cap frame drop _pip_gd` will return an error code because you can't drop the frame currently loaded (`_pip_gd`).  This PR patches this.